### PR TITLE
Adds support for Laravel 9 to v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "library",
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
-        "illuminate/console": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/console": "^5.0|^6.0|^7.0|^8.0|^9.0",
         "balping/json-raw-encoder": "^1.0"
     },
     "authors": [


### PR DESCRIPTION
Laravel 9 is just around the corner (due in 5 days). I thought we'd get ahead of this thing and provide support for it before it launches. I've tested v6 against Laravel 9 and... it still works like a charm! 🎉

![Screenshot 2022-01-20 at 07 33 20](https://user-images.githubusercontent.com/1032474/150279638-054fada1-66bf-4826-81d3-5bfd7f3fb1ca.png)
![Screenshot 2022-01-20 at 07 33 30](https://user-images.githubusercontent.com/1032474/150279642-3e1561f6-aef2-48de-9f15-69322d10517e.png)
![Screenshot 2022-01-20 at 07 33 38](https://user-images.githubusercontent.com/1032474/150279646-f5d81f63-b6b0-4531-a325-2ed73feadc9c.png)

The only thing for it to be installable on L9 is a dependency version bump. So that's what this PR does.