### PR TITLE
Add support for laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "type": "library",
     "require": {
         "php": ">=7.4",
-        "illuminate/contracts": "^7.14.1|^8.0",
-        "illuminate/http": "^7.14.1|^8.0",
-        "illuminate/console": "^7.14.1|^8.0",
-        "illuminate/support": "^7.14.1|^8.0",
+        "illuminate/contracts": "^7.14.1|^8.0|^9.0",
+        "illuminate/http": "^7.14.1|^8.0|^9.0",
+        "illuminate/console": "^7.14.1|^8.0|^9.0",
+        "illuminate/support": "^7.14.1|^8.0|^9.0",
         "chartisan/php": "^1.2.0"
     },
     "authors": [


### PR DESCRIPTION
Laravel 9 is out!

The only thing for it to be installable on L9 is a dependency version bump. So that's what this PR does.